### PR TITLE
Feature/gh 8 test sources dir chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Show a popup to select a test source root to generate the test mother in if there are multiple
+  test source roots.
+
 ## [0.0.2] - 2023-11-09
 
 ### Changed

--- a/src/main/kotlin/be/sweetmustard/testnurturer/GenerateTestMotherAction.kt
+++ b/src/main/kotlin/be/sweetmustard/testnurturer/GenerateTestMotherAction.kt
@@ -194,7 +194,7 @@ class GenerateTestMotherAction : AnAction() {
     ) {
         JBPopupFactory.getInstance().createPopupChooserBuilder(testSourceRoots)
             .setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-            .setTitle("Choose test sources root to generate Test Mother in for " + selectedClass.name)
+            .setTitle("Choose test sources root for " + selectedClass.name + " Test Mother generation")
             .setRenderer(object : ColoredListCellRenderer<VirtualFile>() {
                 override fun customizeCellRenderer(
                     list: JList<out VirtualFile>,


### PR DESCRIPTION
This PR has the plugin support multiple test sources directories. If the plugin detects that the project has multiple test sources, then the user must select one of those when generating the test mother.